### PR TITLE
Fixed method signature formatting to preserve accessor names

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/subhook"]
     path = third_party/subhook
-    url = https://github.com/Zeex/subhook.git
+    url = https://github.com/Dasharo/subhook.git

--- a/do_lib/avm.h
+++ b/do_lib/avm.h
@@ -39,6 +39,7 @@ namespace avm
         TRAIT_Getter    = 0x02,
         TRAIT_Setter    = 0x03,
         TRAIT_Class     = 0x04,
+        TRAIT_Function  = 0x05,
         TRAIT_Const     = 0x06,
         TRAIT_COUNT     = TRAIT_Const+1,
         TRAIT_mask      = 15
@@ -469,10 +470,7 @@ namespace avm
             return result;
         }
 
-        std::string name()
-        {
-            return pool->get_method_name(id);
-        }
+        std::string name();
 
         inline bool compiled() {
             return ((flags >> 21) & 1) == 1;

--- a/do_lib/darkorbit.cpp
+++ b/do_lib/darkorbit.cpp
@@ -339,13 +339,13 @@ std::string Darkorbit::get_method_signature(avm::MethodInfo *mi, bool method_nam
         if (method_name) {
             std::string mn = mi->name();
             if (mn.empty()) return "";
-
+            
+            ss << "(";
             auto index = mn.find('/');
             if (index != std::string::npos) {
-                mn[index] = ' ';
-            }
-
-            ss << "(" << mn << ")";
+                ss << mn.substr(index + 1);
+            } else ss << mn;
+            ss << ")";
         }
 
         ss << "(";

--- a/do_lib/darkorbit.cpp
+++ b/do_lib/darkorbit.cpp
@@ -339,7 +339,7 @@ std::string Darkorbit::get_method_signature(avm::MethodInfo *mi, bool method_nam
         if (method_name) {
             std::string mn = mi->name();
             if (mn.empty()) return "";
-            
+
             ss << "(";
             auto index = mn.find('/');
             if (index != std::string::npos) {

--- a/do_lib/darkorbit.cpp
+++ b/do_lib/darkorbit.cpp
@@ -340,12 +340,12 @@ std::string Darkorbit::get_method_signature(avm::MethodInfo *mi, bool method_nam
             std::string mn = mi->name();
             if (mn.empty()) return "";
 
-            ss << "(";
             auto index = mn.find('/');
             if (index != std::string::npos) {
-                ss << mn.substr(index + 1);
-            } else ss << mn;
-            ss << ")";
+                mn[index] = ' ';
+            }
+
+            ss << "(" << mn << ")";
         }
 
         ss << "(";


### PR DESCRIPTION
The signature to check `23(set target)(2626)1016221500` but returns `23(target)(2626)1016221500`